### PR TITLE
fix for netplugin service registeration repetitive failures

### DIFF
--- a/etcdLock.go
+++ b/etcdLock.go
@@ -285,8 +285,8 @@ func (ep *Lock) waitForLock() {
 
 // Refresh lock
 func (ep *Lock) refreshLock() {
-	// Refresh interval is 40% of TTL
-	refreshIntvl := time.Second * time.Duration(ep.ttl*3/10)
+	// Refresh interval is 1/3rd of TTL
+	refreshIntvl := time.Second * time.Duration(ep.ttl/3)
 	keyName := "/contiv.io/lock/" + ep.name
 
 	// Loop forever

--- a/etcdService.go
+++ b/etcdService.go
@@ -269,7 +269,13 @@ func refreshService(client *etcd.Client, keyName string, keyVal string, stopChan
 
 			_, err := client.Update(keyName, keyVal, SERVICE_TTL)
 			if err != nil {
-				log.Errorf("Error updating key %s, Err: %v", keyName, err)
+				log.Warnf("Error updating key %s, Err: %v", keyName, err)
+				// In case of a TTL expiry, this key may have been deleted
+				// from the etcd db. Hence use of Set instead of Update
+				_, err := client.Set(keyName, keyVal, SERVICE_TTL)
+				if err != nil {
+					log.Errorf("Error setting key %s, Err: %v", keyName, err)
+				}
 			}
 
 		case <-stopChan:


### PR DESCRIPTION
In case of a TTL expiry, when the entry is deleted from etcd, netplugin needs to use a Set instead of Update to re-create the entry.