### PR TITLE
Hostname is added for service info

### DIFF
--- a/consulService.go
+++ b/consulService.go
@@ -127,6 +127,7 @@ func (cp *ConsulClient) RegisterService(serviceInfo ServiceInfo) error {
 		Port:        serviceInfo.Port,
 		SessionID:   sessionID,
 		stopChan:    stopChan,
+		Hostname:    serviceInfo.Hostname,
 	}
 
 	return nil

--- a/consulService.go
+++ b/consulService.go
@@ -35,6 +35,7 @@ type consulServiceState struct {
 	Port        int           // Port number where its listening
 	SessionID   string        // session id assigned by consul
 	stopChan    chan struct{} // Channel to stop ttl refresh
+	Hostname    string        // Host name where its running
 }
 
 // RegisterService registers a service

--- a/etcdService.go
+++ b/etcdService.go
@@ -35,6 +35,7 @@ type etcdServiceState struct {
 	TTL         time.Duration // TTL for the service
 	HostAddr    string        // Host name or IP address where its running
 	Port        int           // Port number where its listening
+	Hostname    string        // Host name where its running
 
 	// Channel to stop ttl refresh
 	stopChan chan bool

--- a/etcdService.go
+++ b/etcdService.go
@@ -71,6 +71,7 @@ func (ep *EtcdClient) RegisterService(serviceInfo ServiceInfo) error {
 		HostAddr:    serviceInfo.HostAddr,
 		Port:        serviceInfo.Port,
 		stopChan:    make(chan bool, 1),
+		Hostname:    serviceInfo.Hostname,
 	}
 
 	// Run refresh in background

--- a/objdb.go
+++ b/objdb.go
@@ -56,6 +56,7 @@ type ServiceInfo struct {
 	TTL         int    // TTL for this service
 	HostAddr    string // Host name or IP address where its running
 	Port        int    // Port number where its listening
+	Hostname    string // Host name where its running
 }
 
 // Watch events


### PR DESCRIPTION
For bgpinspect we need host name to ip translation hence all netplugins register service info with their host name included.