### PR TITLE
etcdClient.go: fixed a bug where nil was returned instead of err

### DIFF
--- a/etcdClient.go
+++ b/etcdClient.go
@@ -161,7 +161,7 @@ func (ep *EtcdClient) ListDir(key string) ([]string, error) {
 			}
 		}
 		if err != nil {
-			return nil, nil
+			return nil, err
 		}
 	}
 


### PR DESCRIPTION
Signed-off-by: Bill Robinson <dseevr@users.noreply.github.com>

This bug is _not_ present in consulClient.go